### PR TITLE
Fix getInput()

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var defaultOptions = {
 };
 
 var getInput = function() {
-  return loaderUtils.getRemainingRequest(this);
+  return this.resourcePath;
 };
 
 var getOptions = function() {


### PR DESCRIPTION
I am not sure I understand the issue, but without this fix, the input comes in as: '.../node_modules/elm-webpack-loader/index.js!..../Stylesheets.elm'

I looked at elm-webpack-loader and it looks it uses this.resourcePath instead of loaderUtils.getRemainingRequest
