### PR TITLE
Fix embed call

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -3,4 +3,4 @@
 require('./index.html');
 require('./src/Stylesheets');
 var Elm = require('./src/HomepageView');
-Elm.embed(Elm.HomepageView, document.getElementById('main'));
+Elm.HomepageView.embed(document.getElementById('main'));


### PR DESCRIPTION
The API was changed for embedding modules -- This fixes the example being broken when running it.
