### PR TITLE
Allow Elm 0.18's --debug flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var temp = require('temp').track();
 
 var cachedDependencies = [];
 
-var validOptions = ['cwd', 'cache', 'yes', 'emitWarning'];
+var validOptions = ['cwd', 'cache', 'yes', 'emitWarning', 'debug'];
 
 var defaultOptions = {
   cwd: ".",


### PR DESCRIPTION
Also, for some reason the error output that I was passing in an unsupported flag didn't show in my web pack output. I found out what was wrong with good old console logs. Sorry I didn't take the time to find out why. Thanks for providing this loader!